### PR TITLE
Implement trait analysis screen

### DIFF
--- a/job_simulation_v6.html
+++ b/job_simulation_v6.html
@@ -1,0 +1,554 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>직업 시뮬레이션 Pro</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <style>
+        body { font-family: 'Noto Sans KR', sans-serif; }
+        .fade-in { animation: a-fade-in 0.5s ease-out forwards; }
+        .fade-out { animation: a-fade-out 0.3s ease-in forwards; }
+        .message-bubble-in { animation: a-message-bubble-in 0.4s ease-out forwards; }
+        @keyframes a-fade-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+        @keyframes a-fade-out { from { opacity: 1; } to { opacity: 0; } }
+        @keyframes a-message-bubble-in { from { opacity: 0; transform: translateY(10px); } to { opacity: 1; transform: translateY(0); } }
+        .loading-dots span { animation: a-dot-pulse 1.4s infinite; display: inline-block; opacity: 0; }
+        .loading-dots span:nth-child(2) { animation-delay: 0.2s; }
+        .loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+        @keyframes a-dot-pulse { 0%, 100% { opacity: 0; } 50% { opacity: 1; } }
+    </style>
+</head>
+<body class="bg-gray-100 flex justify-center items-center h-screen p-4">
+
+    <div id="app-container" class="w-full max-w-lg h-full bg-white flex flex-col shadow-2xl rounded-2xl overflow-hidden ring-1 ring-gray-900/5">
+
+        <!-- 화면 1: 시나리오 선택 -->
+        <div id="selection-screen" class="flex flex-col h-full">
+            <header class="bg-gradient-to-r from-gray-800 to-gray-900 text-white p-5 flex-shrink-0 shadow-lg">
+                <h1 class="text-2xl font-bold text-center">직업 시뮬레이션 Pro</h1>
+                <p class="text-center text-sm text-gray-300 mt-1">체험할 직업을 선택하세요.</p>
+            </header>
+            <main id="scenario-list" class="flex-grow p-3 sm:p-5 overflow-y-auto bg-gray-50 space-y-3"></main>
+        </div>
+
+        <!-- 화면 2: 시뮬레이션 (채팅) -->
+        <div id="simulation-screen" class="hidden flex-col h-full">
+            <header id="simulation-header" class="bg-gradient-to-r from-blue-600 to-indigo-700 text-white p-4 flex-shrink-0 flex items-center shadow-md">
+                <button id="back-to-selection" class="p-2 mr-2 rounded-full hover:bg-white/20 transition-colors">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" /></svg>
+                </button>
+                <h1 id="simulation-title" class="text-xl font-bold text-center flex-grow"></h1>
+                <div class="w-10"></div>
+            </header>
+            <main id="chat-window" class="flex-grow p-4 overflow-y-auto bg-white"></main>
+            <footer class="flex-shrink-0 p-3 bg-gray-50 border-t">
+                <div id="hint-buttons-container" class="flex flex-wrap justify-center gap-2 mb-2"></div>
+                <form id="message-form" class="flex items-center space-x-3">
+                    <button type="button" id="show-hints-button" title="추천 답변 보기" class="p-3 border rounded-full hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-colors">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-yellow-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                            <path stroke-linecap="round" stroke-linejoin="round" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 017.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
+                        </svg>
+                    </button>
+                    <input type="text" id="message-input" placeholder="어떻게 행동하시겠습니까?" class="flex-grow p-3 border border-gray-300 rounded-full focus:outline-none focus:ring-2 focus:ring-blue-500 transition-shadow" autocomplete="off">
+                    <button type="submit" id="submit-button" class="bg-blue-600 text-white rounded-full p-3 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-all duration-300 transform hover:scale-110">
+                        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>
+                    </button>
+                </form>
+            </footer>
+        </div>
+
+        <!-- 화면 3: 성향 분석 결과 -->
+        <div id="analysis-screen" class="hidden flex-col h-full">
+            <header class="bg-gradient-to-r from-purple-600 to-indigo-700 text-white p-4 flex-shrink-0 shadow-md">
+                <h1 class="text-xl font-bold text-center w-full">플레이어 성향 분석 결과</h1>
+            </header>
+            <main class="flex-grow p-4 overflow-y-auto bg-white space-y-4">
+                <h2 id="analysis-summary" class="text-center text-lg font-semibold"></h2>
+                <canvas id="analysis-chart" class="w-full max-w-md mx-auto"></canvas>
+                <ul id="analysis-desc" class="text-sm space-y-1"></ul>
+            </main>
+            <footer class="flex-shrink-0 p-3 bg-gray-50 border-t">
+                <button id="analysis-back" class="w-full bg-gray-800 text-white py-3 rounded-xl font-semibold hover:bg-gray-900 transition-transform transform hover:scale-105">메인으로 돌아가기</button>
+            </footer>
+        </div>
+    </div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        try {
+            // DOM 요소 캐싱
+            const selectionScreen = document.getElementById('selection-screen');
+            const simulationScreen = document.getElementById('simulation-screen');
+            const analysisScreen = document.getElementById('analysis-screen');
+            const scenarioList = document.getElementById('scenario-list');
+            const chatWindow = document.getElementById('chat-window');
+            const messageForm = document.getElementById('message-form');
+            const messageInput = document.getElementById('message-input');
+            const simulationTitle = document.getElementById('simulation-title');
+            const backButton = document.getElementById('back-to-selection');
+            const analysisBackButton = document.getElementById('analysis-back');
+            const submitButton = document.getElementById('submit-button');
+            const hintButtonsContainer = document.getElementById('hint-buttons-container');
+            const showHintsButton = document.getElementById('show-hints-button');
+            const analysisSummary = document.getElementById('analysis-summary');
+            const analysisChartCanvas = document.getElementById('analysis-chart');
+            const analysisDesc = document.getElementById('analysis-desc');
+
+            // API 설정
+            const API_KEY = "AIzaSyAvxZtajCujNI252y1Yd01VPNr402iyl9o";
+            const API_URL = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-flash-latest:generateContent?key=${API_KEY}`;
+
+            const SYSTEM_PROMPT = `당신은 '직업 시뮬레이션 게임'의 전문 스토리 마스터입니다. 당신의 역할은 사용자의 행동에 대해, 주어진 규칙에 따라 가장 개연성 있는 다음 상황을 생성하는 것입니다.\n\n규칙:\n1.  **결과 중심 서술**: 당신의 응답은 반드시 사용자 행동이 직접적으로 초래한 \'결과\'여야 합니다. 과정을 설명하거나 사용자의 행동을 단순히 반복하지 마세요.\n2.  **창의성 존중**: 사용자의 행동이 다소 창의적이거나 예상치 못한 것이더라도, 그것이 시나리오의 개연성을 해치지 않는다면 긍정적으로 수용하고 그에 따른 논리적인 다음 상황이나 딜레마를 제시하세요. 정해진 정답을 강요하지 마세요.\n3.  **해결 금지**: 절대로 문제를 대신 해결해주지 마세요. 항상 새로운 도전 과제, 예상치 못한 문제, 혹은 어려운 선택지를 제시하여 사용자가 계속해서 고민하게 만드세요.\n4.  **스토리 진행**: 사용자의 행동이 3~4회 누적되면, 그동안의 행동 결과를 종합하여 이야기를 절정으로 이끌거나 성공/실패의 분기점을 명확히 제시하세요. 무한히 새로운 문제만 제시하지 마세요.\n5.  **분량 엄수**: 응답은 반드시 2개의 문장으로 간결하게 작성하세요. 장황한 설명은 금물입니다.\n6.  **힌트 제공**: 응답 마지막에는 다음 행동에 대한 추천 선택지 2개를 \[힌트\] 태그와 함께 제안해야 합니다. (예: \[힌트\] 1. 새로운 증거를 분석한다. 2. 증인과 다시 대화한다.\)\
+7.  **엔딩 처리**: 사용자의 행동으로 이야기가 명확히 종결되었다고 판단될 경우, 다른 설명 없이 \[엔딩:성공\]\, \[엔딩:실패\]\, \[엔딩:보통\] 태그 중 하나만 응답하세요. 엔딩 발생 시에는 \[힌트\]를 생략합니다.`
+
+            const ANALYSIS_PROMPT = `당신은 플레이어의 행동 패턴을 분석하는 고도로 숙련된 심리 분석가입니다. 당신의 임무는 주어진 시뮬레이션 게임 대화 기록을 검토하고, 플레이어의 성향을 6가지 지표에 따라 평가하는 것입니다.
+
+[분석 절차]
+1.  주어진 대화 기록에서 'user'의 역할로 입력된 모든 응답을 전체적으로 검토합니다.
+2.  아래 [6대 지표 평가 기준]에 따라 각 지표의 점수를 1점에서 10점 사이로 평가합니다.
+3.  다른 설명은 일절 추가하지 말고, 오직 유효한 JSON 객체 형식으로만 결과를 반환해야 합니다.
+
+[6대 지표 평가 기준]
+* **분석력**: 정보를 요구하거나, 증거를 찾거나, 상황의 원인을 논리적으로 추론하는가? (높은 점수: "증거를 자세히 살펴본다", "다른 목격자는 없는가?")
+* **창의성**: 예상치 못한 방법이나 기발한 아이디어를 제안하는가? (높은 점수: "주변의 소화기를 이용해 벽을 부순다", "라이벌 셰프와 협업 메뉴를 제안한다")
+* **결단력**: 신속하고 단호하게 행동을 결정하는가? 망설임이 적은가? (높은 점수: "즉시 응급처치를 시작한다", "지체 없이 계획을 실행한다")
+* **공감력**: 다른 인물의 감정을 고려하거나, 설득, 위로, 협력을 시도하는가? (높은 점수: "피해자를 먼저 안정시킨다", "의뢰인의 이야기를 끝까지 들어준다")
+* **신중함**: 위험 요소를 먼저 확인하거나, 행동의 결과를 예측하거나, 안전한 계획을 세우는가? (높은 점수: "함정이 있는지 먼저 확인한다", "행동하기 전 상부에 보고한다")
+* **주도성**: 상황을 통제하려 하거나, 명확한 지시를 내리거나, 대화의 방향을 이끄는가? (높은 점수: "팀원들에게 역할을 분담시킨다", "내가 앞장서겠다")
+
+[출력 형식]
+{
+  "분석력": [1-10 사이의 정수],
+  "창의성": [1-10 사이의 정수],
+  "결단력": [1-10 사이의 정수],
+  "공감력": [1-10 사이의 정수],
+  "신중함": [1-10 사이의 정수],
+  "주도성": [1-10 사이의 정수]
+}`;
+
+            const TRAIT_DESCRIPTIONS = {
+                '분석력': '당신은 감보다 데이터를, 추측보다 명확한 근거를 신뢰하는군요. 문제의 핵심을 꿰뚫어 보는 능력이 뛰어납니다.',
+                '창의성': '정해진 길을 따르기보다 자신만의 길을 개척하는 것을 즐기는군요. 당신의 기발함은 막다른 길을 새로운 기회로 만듭니다.',
+                '결단력': '고민은 짧게, 행동은 과감하게! 당신의 신속한 판단력은 위기 상황에서 특히 빛을 발합니다.',
+                '공감력': '당신은 사람의 마음을 움직이는 힘을 알고 있습니다. 논리만으로는 해결할 수 없는 문제를 푸는 열쇠를 쥐고 있군요.',
+                '신중함': '돌다리도 두들겨 보고 건너는 당신의 신중함은 치명적인 실수를 방지하는 가장 강력한 무기입니다.',
+                '주도성': '당신은 방관자가 아닌 지휘자가 되는 것을 선택하는군요. 명확한 목표를 향해 주변을 이끄는 힘이 있습니다.'
+            };
+            let conversationHistory = [];
+            let currentHints = [];
+            let currentScenario = null;
+
+            // 시나리오 데이터
+            const scenarios = [
+                {
+                    id: `chef`,
+                    title: `라이벌 식당의 도전`,
+                    description: `당신이 운영하는 작은 레스토랑 맞은편에 유명 셰프가 새 레스토랑을 열었습니다. 단골 손님들이 줄어들기 시작합니다.`,
+                    initialPrompt: `당신은 작은 이탈리안 레스토랑 '라 루나'의 오너 셰프, 박선우입니다. 당신의 식당은 동네에서 꽤 인기가 있었지만, 바로 길 건너편에 TV에도 출연한 유명 셰프 '에드워드 강'이 화려한 레스토랑을 열었습니다. 오픈 이후, 당신의 단골 손님들의 발길이 눈에 띄게 줄었고, 저녁 예약이 텅 비는 날이 생겼습니다. 당신은 어떻게 행동하시겠습니까?`,
+                    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 8v13m0-13V6a2 2 0 112 2h-2zm0 0V5.5A2.5 2.5 0 109.5 8H12zm-7 4h14M5 12a2 2 0 110-4h14a2 2 0 110 4M5 12v7a2 2 0 002 2h10a2 2 0 002-2v-7" /></svg>`,
+                    imageUrl: `https://images.unsplash.com/photo-1555243896-c709bfa0b564?q=80&w=1200&auto=format&fit=crop`,
+                    initialHints: [`다른 셰프들의 반응을 살핀다.`, `우리 식당만의 새로운 메뉴를 개발한다.`],
+                    endings: {
+                        '성공': `당신의 창의적인 메뉴와 노력 끝에 손님들이 다시 찾아오기 시작했습니다. 라이벌 셰프도 당신의 실력을 인정하며, 이제 두 레스토랑은 선의의 경쟁을 하는 동네의 명물이 되었습니다.`,
+                        '실패': `결국 줄어드는 손님을 감당하지 못하고, 당신은 쓸쓸히 레스토랑의 문을 닫게 되었습니다. 때로는 빠른 포기도 중요한 법입니다.`,
+                        '보통': `몇 가지 신메뉴로 일부 단골을 되찾았지만, 라이벌 식당의 인기는 여전합니다. 현상 유지는 했지만, 앞으로의 길이 험난해 보입니다.`
+                    }
+                },
+                {
+                    id: `paramedic`,
+                    title: `위급한 교통사고 현장`,
+                    description: `대형 추돌사고 현장에 가장 먼저 도착했습니다. 부상자가 여러 명이고, 현장은 아수라장입니다.`,
+                    initialPrompt: `당신은 119 구급대원, 김민준입니다. 대형 트럭과 승용차 여러 대가 얽힌 연쇄 추돌사고 신고를 받고 현장에 가장 먼저 도착했습니다. 여기저기서 부상자들의 신음 소리가 들리고, 한 차량에서는 연기가 피어오르고 있습니다. 추가 지원팀이 도착하기까지는 최소 10분이 걸리는 상황입니다. 당신은 어떻게 행동하시겠습니까?`,
+                    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-red-500" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v2H7a1 1 0 100 2h2v2a1 1 0 102 0v-2h2a1 1 0 100-2h-2V7z" clip-rule="evenodd" /></svg>`,
+                    imageUrl: `https://images.unsplash.com/photo-1713623311317-d3c43a4be4cf?q=80&w=1674&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D`,
+                    initialHints: [`현장 상황을 즉시 지휘 본부에 보고한다.`, `가장 위급해 보이는 부상자에게 먼저 다가간다.`],
+                    endings: {
+                        '성공': `신속하고 정확한 판단으로 위험을 최소화하고 모든 부상자를 안전하게 구조했습니다. 당신의 활약 덕분에 귀중한 생명들을 구할 수 있었습니다.`,
+                        '실패': `우선순위 판단 착오와 미흡한 대처로 일부 부상자의 상태가 악화되었습니다. 최선을 다했지만, 안타까운 결과를 피할 수 없었습니다.`,
+                        '보통': `몇몇 부상자를 응급처치했지만, 현장의 혼란 속에서 모든 상황을 통제하지는 못했습니다. 지원팀 도착 후 상황은 수습되었지만 아쉬움이 남습니다.`
+                    }
+                },
+                {
+                    id: `lawyer`,
+                    title: `불리한 증거와 억울한 의뢰인`,
+                    description: `당신은 명백히 억울해 보이는 의뢰인을 변호하고 있지만, 재판에 결정적으로 불리한 증거가 제출되었습니다.`,
+                    initialPrompt: `당신은 형사 전문 변호사, 이하은입니다. 당신은 억울하게 절도 혐의를 받고 있는 청년을 변호하고 있습니다. 그의 무죄를 확신했지만, 방금 검찰 측에서 의뢰인의 지문이 묻은 범행 도구가 결정적 증거로 제출했습니다. 의뢰인은 결백을 주장하며 절망에 빠졌습니다. 공판이 내일 오전에 재개됩니다. 당신은 어떻게 행동하시겠습니까?`,
+                    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-gray-700" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 6l3 1m0 0l-3 9a5.002 5.002 0 006.001 0M6 7l3 9M6 7l6-2m6 2l-6-2m6 2l3-1m-3 1l-3 9a5.002 5.002 0 006.001 0M18 7l3 9m-3-9l-6-2" /></svg>`,
+                    imageUrl: `https://plus.unsplash.com/premium_photo-1698084059560-9a53de7b816b?q=80&w=1711&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D`,
+                    initialHints: [`증거가 조작되었을 가능성을 제기한다.`, `의뢰인을 만나 다시 한번 상황을 들어본다.`],
+                    endings: {
+                        '성공': `끈질긴 재조사 끝에 결정적 증거가 조작되었음을 밝혀냈습니다. 법정에서 의뢰인의 무죄를 극적으로 증명하며 완벽한 승리를 거머쥐었습니다.`,
+                        '실패': `결정적인 증거를 뒤집지 못하고 의뢰인은 유죄 판결을 받았습니다. 최선을 다했지만, 변호사로서의 깊은 무력감을 느끼게 되었습니다.`,
+                        '보통': `증거의 신빙성이 부족하다는 주장이 받아들여져 감형을 받는 데 성공했습니다. 완전한 무죄는 아니지만, 최악의 상황은 피했습니다.`
+                    }
+                },
+                {
+                    id: `teacher`,
+                    title: `교실 안의 따돌림 문제`,
+                    description: `당신의 반에서 한 학생이 다른 아이들에게 따돌림을 당하고 있다는 사실을 알게 되었습니다.`,
+                    initialPrompt: `당신은 초등학교 3학년 담임 교사, 정다솜입니다. 쉬는 시간에 한 학생이 울면서 찾아와, 같은 반 친구 여러 명이 자신을 놀리고 끼워주지 않는다고 털어놓았습니다. 가해자로 지목된 아이들은 평소에는 문제가 없어 보이던 학생들이었습니다. 이 문제를 해결해야 하지만, 섣부른 개입은 상황을 악화시킬 수 있습니다. 당신은 어떻게 행동하시겠습니까?`,
+                    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" /></svg>`,
+                    imageUrl: `https://images.unsplash.com/photo-1588075592446-265fd1e6e76f?q=80&w=1200&auto=format&fit=crop`,
+                    initialHints: [`다른 학생들의 증언을 확보한다.`, `가해 학생과 피해 학생을 따로따로 상담한다.`],
+                    endings: {
+                        '성공': `세심한 상담과 학급 활동을 통해 아이들이 서로의 마음을 이해하도록 도왔습니다. 따돌림 문제가 해결되고, 교실에는 따뜻한 분위기가 자리 잡았습니다.`,
+                        '실패': `섣부른 개입이 오히려 피해 학생을 더 고립시키는 결과를 낳았습니다. 문제는 수면 아래로 가라앉아 해결하기 더욱 어려워졌습니다.`,
+                        '보통': `개별 상담을 통해 직접적인 괴롭힘은 멈추게 했지만, 아이들 사이에 서먹한 기류는 여전합니다. 급한 불은 껐지만, 갈등의 불씨는 남아있습니다.`
+                    }
+                },
+                {
+                    id: `archaeologist`,
+                    title: `세기의 발견과 위험한 함정`,
+                    description: `고대 유적지에서 전설로만 전해지던 유물을 발견했지만, 유물을 집어 들자 주변의 함정이 작동하기 시작했습니다.`,
+                    initialPrompt: `당신은 고고학자, '인디아나' 정입니다. 수년간의 탐사 끝에, 당신은 안데스 산맥 깊은 곳에서 전설로만 전해지던 '태양의 눈물' 유물을 발견했습니다. 조심스럽게 유물을 집어 드는 순간, 발밑의 돌판이 흔들리며 사방에서 벽이 움직이는 소리가 들려옵니다. 유적 전체가 무너지기 시작하는 것 같습니다. 당신은 어떻게 행동하시겠습니까?`,
+                    icon: `<svg xmlns="http://www.w3.org/2000/svg" class="h-8 w-8 text-yellow-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>`,
+                    imageUrl: `https://images.unsplash.com/photo-1592488831370-fe3692a465a3?q=80&w=2073&auto=format&fit=crop&ixlib=rb-4.1.0&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D`,
+                    initialHints: [`유물 대신 다른 물건을 올려놓는다.`, `함정이 없는 다른 탈출 경로를 찾는다.`],
+                    endings: {
+                        '성공': `고대 장치에 대한 지식과 빠른 판단력으로 무너지는 함정을 돌파하여 '태양의 눈물'을 손에 넣고 무사히 탈출했습니다. 당신의 이름은 역사에 기록될 것입니다.`,
+                        '실패': `함정을 피하려다 잘못된 통로로 들어서는 바람에 유적에 영원히 갇히고 말았습니다. '태양의 눈물'은 다시 세상에서 잊혀졌습니다.`,
+                        '보통': `유물을 가지고는 탈출할 수 없다는 사실을 깨닫고, 아쉽지만 '태양의 눈물'을 제자리에 내려놓은 채 간신히 목숨만 건져 탈출했습니다. 발견은 미완으로 남았습니다.`
+                    }
+                }
+            ];
+
+            // 함수 선언
+            function renderSelectionScreen() {
+                scenarioList.innerHTML = '';
+                scenarios.forEach((scenario, index) => {
+                    const card = document.createElement('div');
+                    card.className = 'start-button bg-white p-5 rounded-xl shadow-sm border border-gray-200 flex items-center space-x-4 cursor-pointer hover:shadow-lg hover:ring-2 hover:ring-blue-500 transition-all duration-300 transform hover:-translate-y-1 fade-in';
+                    card.dataset.scenarioId = scenario.id;
+                    card.style.animationDelay = `${index * 100}ms`;
+                    card.innerHTML = `
+                        <div class="flex-shrink-0 bg-gray-100 p-3 rounded-full">${scenario.icon}</div>
+                        <div class="flex-grow">
+                            <h3 class="text-lg font-bold text-gray-800">${scenario.title}</h3>
+                            <p class="text-sm text-gray-500">${scenario.description}</p>
+                        </div>
+                        <div class="flex-shrink-0">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>
+                        </div>`;
+                    scenarioList.appendChild(card);
+                });
+            }
+            
+            function startSimulation(scenarioId) {
+                const scenario = scenarios.find(s => s.id === scenarioId);
+                if (!scenario) return;
+
+                currentScenario = scenario;
+                selectionScreen.classList.add('fade-out');
+                setTimeout(() => {
+                    selectionScreen.classList.add('hidden');
+                    selectionScreen.classList.remove('fade-out');
+                    chatWindow.innerHTML = '';
+                    conversationHistory = [];
+                    currentHints = scenario.initialHints || [];
+                    simulationTitle.textContent = scenario.title;
+                    
+                    simulationScreen.classList.remove('hidden');
+                    simulationScreen.classList.add('flex', 'fade-in');
+
+                    if (scenario.imageUrl) {
+                        addImageMessage(scenario.imageUrl);
+                    }
+                    addMessage(scenario.initialPrompt);
+                    conversationHistory.push({ role: "model", parts: [{ text: scenario.initialPrompt }] });
+                    toggleInput(true, currentHints.length > 0);
+                    messageInput.focus();
+                }, 300);
+            }
+            
+            function resetAndShowSelection() {
+                simulationScreen.classList.add('fade-out');
+                analysisScreen.classList.add('fade-out');
+                setTimeout(() => {
+                    simulationScreen.classList.add('hidden');
+                    simulationScreen.classList.remove('flex', 'fade-out', 'fade-in');
+                    analysisScreen.classList.add('hidden');
+                    analysisScreen.classList.remove('flex', 'fade-out', 'fade-in');
+                    selectionScreen.classList.remove('hidden');
+                    selectionScreen.classList.add('fade-in');
+                    messageInput.value = '';
+                    toggleInput(false, false);
+                    analysisDesc.innerHTML = '';
+                    analysisSummary.textContent = '';
+                    if (analysisChartCanvas._chart) {
+                        analysisChartCanvas._chart.destroy();
+                    }
+                }, 300);
+            }
+
+            function addImageMessage(url) {
+                const wrapper = document.createElement('div');
+                wrapper.className = 'flex justify-center mb-4 message-bubble-in';
+                wrapper.innerHTML = `<div class="w-full max-w-md rounded-xl overflow-hidden shadow-lg bg-gray-200"><img src="${url}" alt="시나리오 이미지" loading="lazy" class="w-full h-auto object-cover" onerror="this.style.display='none'; this.parentElement.innerHTML='<div class=&quot;p-4 text-center text-red-500&quot;>이미지를 불러올 수 없습니다.</div>';"></div>`;
+                chatWindow.appendChild(wrapper);
+                scrollToBottom();
+            }
+            
+            function addMessage(text, isUser = false) {
+                const wrapper = document.createElement('div');
+                wrapper.className = `flex mb-4 message-bubble-in ${isUser ? 'justify-end' : 'justify-start'}`;
+                wrapper.innerHTML = `<div class="rounded-2xl py-2.5 px-4 max-w-[85%] sm:max-w-[80%] break-words shadow-sm ${isUser ? 'bg-blue-600 text-white rounded-br-lg' : 'bg-gray-200 text-gray-800 rounded-bl-lg'}">${text.replace(/\n/g, '<br>')}</div>`;
+                chatWindow.appendChild(wrapper);
+                scrollToBottom();
+            }
+            
+            function toggleLoadingIndicator(show) {
+                let loadingEl = document.getElementById('loading-indicator');
+                if (show) {
+                    if (!loadingEl) {
+                        loadingEl = document.createElement('div');
+                        loadingEl.id = 'loading-indicator';
+                        loadingEl.className = 'flex justify-start mb-4 message-bubble-in';
+                        loadingEl.innerHTML = `<div class="rounded-2xl rounded-bl-lg py-2.5 px-4 bg-gray-200"><div class="loading-dots"><span>●</span><span>●</span><span>●</span></div></div>`;
+                        chatWindow.appendChild(loadingEl);
+                        scrollToBottom();
+                    }
+                } else {
+                    if (loadingEl) loadingEl.remove();
+                }
+            }
+            
+            function displayHintButtons() {
+                hintButtonsContainer.innerHTML = '';
+                if (!currentHints || currentHints.length === 0) return;
+
+                currentHints.forEach(hint => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'hint-button bg-gray-200 text-gray-700 text-sm px-3 py-1.5 rounded-full hover:bg-gray-300 transition-colors fade-in';
+                    button.textContent = hint;
+                    button.onclick = () => {
+                        messageInput.value = hint;
+                        messageInput.focus();
+                    };
+                    hintButtonsContainer.appendChild(button);
+                });
+            }
+
+            function addEndingMessage(text, type) {
+                const typeInfo = {
+                    '성공': { icon: '🎉', color: 'text-green-600', border: 'border-green-400' },
+                    '실패': { icon: '☠️', color: 'text-red-600', border: 'border-red-400' },
+                    '보통': { icon: '⚖️', color: 'text-gray-600', border: 'border-gray-400' }
+                }[type] || { icon: '❓', color: 'text-gray-600', border: 'border-gray-400' };
+                
+                const wrapper = document.createElement('div');
+                wrapper.className = `ending-card-wrapper my-4 p-4 flex justify-center message-bubble-in`;
+                wrapper.innerHTML = `
+                    <div class="w-full max-w-md bg-white rounded-2xl shadow-xl p-6 text-center border-t-8 ${typeInfo.border}">
+                        <div class="text-6xl mb-4">${typeInfo.icon}</div>
+                        <h2 class="text-3xl font-bold ${typeInfo.color} mb-3">시나리오 완료: ${type}</h2>
+                        <p class="text-gray-700 text-lg mb-8">${text}</p>
+                        <div class="space-y-2">
+                            <button class="analysis-button w-full bg-blue-600 text-white py-3 rounded-xl font-semibold hover:bg-blue-700 transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600">성향 분석하기</button>
+                            <button class="restart-button w-full bg-gray-800 text-white py-3 rounded-xl font-semibold hover:bg-gray-900 transition-transform transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-800">새로운 시나리오 시작하기</button>
+                        </div>
+                    </div>`;
+
+                const restartButton = wrapper.querySelector('.restart-button');
+                const analysisButton = wrapper.querySelector('.analysis-button');
+                if (restartButton) {
+                    restartButton.addEventListener('click', resetAndShowSelection);
+                }
+                if (analysisButton) {
+                    analysisButton.addEventListener('click', startAnalysis);
+                }
+                chatWindow.appendChild(wrapper);
+                scrollToBottom();
+            }
+            
+            function toggleInput(mainInputEnabled, hintsAvailable) {
+                messageInput.disabled = !mainInputEnabled;
+                submitButton.disabled = !mainInputEnabled;
+                showHintsButton.disabled = !hintsAvailable;
+                if (!mainInputEnabled || !hintsAvailable) {
+                    hintButtonsContainer.innerHTML = '';
+                }
+                messageInput.placeholder = mainInputEnabled ? "어떻게 행동하시겠습니까?" : "게임이 종료되었습니다.";
+            }
+
+            async function getLlmResponse() {
+                if (!API_KEY || API_KEY === "여기에_발급받은_API_키를_입력하세요") { 
+                    addMessage("오류: API 키가 설정되지 않았습니다. 스크립트 상단의 API_KEY 변수를 확인하세요."); 
+                    return; 
+                }
+                toggleInput(false, false);
+                toggleLoadingIndicator(true);
+                currentHints = [];
+                
+                try {
+                    const response = await fetch(API_URL, { 
+                        method: 'POST', 
+                        headers: { 'Content-Type': 'application/json' }, 
+                        body: JSON.stringify({ 
+                            systemInstruction: { role: "model", parts: [{ text: SYSTEM_PROMPT }] }, 
+                            contents: conversationHistory 
+                        }) 
+                    });
+
+                    toggleLoadingIndicator(false);
+
+                    if (!response.ok) {
+                        const errorData = await response.json();
+                        throw new Error(`API 오류: ${response.status} - ${errorData.error?.message || '알 수 없는 오류'}`);
+                    }
+
+                    const data = await response.json();
+                    const llmText = data.candidates?.[0]?.content?.parts?.[0]?.text?.trim() || "오류: 응답을 생성하지 못했습니다.";
+                    
+                    const endingMatch = llmText.match(/(.*?)[\[]엔딩:(성공|실패|보통)[\]]$/);
+
+                    if (endingMatch && currentScenario) {
+                        const storyTextBeforeEnding = endingMatch[1].trim();
+                        const endingType = endingMatch[2];
+                        const endingText = currentScenario.endings[endingType] || "시나리오가 마무리되었습니다.";
+                        
+                        if (storyTextBeforeEnding) {
+                            addMessage(storyTextBeforeEnding);
+                            conversationHistory.push({ role: "model", parts: [{ text: storyTextBeforeEnding }] });
+                        }
+
+                        addEndingMessage(endingText, endingType);
+                        toggleInput(false, false);
+                        return;
+                    }
+
+                    const hintSplit = llmText.split('[힌트]');
+                    const storyText = hintSplit[0].trim();
+                    
+                    if(storyText) {
+                        addMessage(storyText);
+                        conversationHistory.push({ role: "model", parts: [{ text: storyText }] });
+                    }
+
+                    let hintsAvailable = false;
+                    if (hintSplit.length > 1) {
+                        currentHints = hintSplit[1].trim().split(/\d\.\s*/).filter(Boolean).map(h => h.trim());
+                        if (currentHints.length > 0) {
+                            hintsAvailable = true;
+                        }
+                    }
+
+                    toggleInput(true, hintsAvailable);
+                    messageInput.focus();
+
+                } catch (error) {
+                    toggleLoadingIndicator(false);
+                    toggleInput(true, false);
+                    addMessage(`치명적인 오류가 발생했습니다: ${error.message}`);
+                }
+            }
+            
+            function scrollToBottom() {
+                chatWindow.scrollTop = chatWindow.scrollHeight;
+            }
+
+            async function startAnalysis() {
+                analysisScreen.classList.remove('hidden');
+                analysisScreen.classList.add('flex');
+                simulationScreen.classList.add('hidden');
+                try {
+                    const response = await fetch(API_URL, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({
+                            systemInstruction: { role: 'model', parts: [{ text: ANALYSIS_PROMPT }] },
+                            contents: conversationHistory
+                        })
+                    });
+                    if (!response.ok) {
+                        const errData = await response.json();
+                        throw new Error(errData.error?.message || '분석 실패');
+                    }
+                    const data = await response.json();
+                    const jsonText = data.candidates?.[0]?.content?.parts?.[0]?.text || '{}';
+                    const scores = JSON.parse(jsonText);
+                    renderAnalysis(scores);
+                } catch (e) {
+                    analysisSummary.textContent = '분석 중 오류 발생: ' + e.message;
+                }
+            }
+
+            function renderAnalysis(scores) {
+                const labels = Object.keys(scores);
+                const values = Object.values(scores);
+                const highestKey = labels[values.indexOf(Math.max(...values))];
+
+                const summaryMap = {
+                    '분석력': "명석한 '분석가'",
+                    '창의성': "독창적인 '창조자'",
+                    '결단력': "과감한 '행동가'",
+                    '공감력': "따뜻한 '조력자'",
+                    '신중함': "신중한 '전략가'",
+                    '주도성': "대담한 '리더'"
+                };
+                analysisSummary.textContent = `당신은 ${summaryMap[highestKey] || highestKey} 유형의 해결사입니다.`;
+
+                analysisDesc.innerHTML = labels.map(k => `<li><strong>${k}</strong>: ${TRAIT_DESCRIPTIONS[k]}</li>`).join('');
+
+                if (analysisChartCanvas._chart) {
+                    analysisChartCanvas._chart.destroy();
+                }
+                analysisChartCanvas._chart = new Chart(analysisChartCanvas, {
+                    type: 'radar',
+                    data: {
+                        labels,
+                        datasets: [{
+                            label: '성향 점수',
+                            data: values,
+                            backgroundColor: 'rgba(99, 102, 241, 0.2)',
+                            borderColor: 'rgba(99, 102, 241, 1)'
+                        }]
+                    },
+                    options: { scales: { r: { suggestedMin: 0, suggestedMax: 10 } } }
+                });
+            }
+
+            // 이벤트 리스너
+            scenarioList.addEventListener('click', (e) => { 
+                const startButton = e.target.closest('.start-button'); 
+                if (startButton) { 
+                    startSimulation(startButton.dataset.scenarioId); 
+                } 
+            });
+
+            messageForm.addEventListener('submit', (e) => { 
+                e.preventDefault(); 
+                const userInput = messageInput.value.trim(); 
+                if (userInput && !messageInput.disabled) {
+                    hintButtonsContainer.innerHTML = ''; // 힌트 버튼 제거
+                    addMessage(userInput, true); 
+                    conversationHistory.push({ role: "user", parts: [{ text: userInput }] }); 
+                    messageInput.value = ''; 
+                    getLlmResponse(); 
+                } 
+            });
+
+            showHintsButton.addEventListener('click', () => {
+                displayHintButtons();
+            });
+
+            backButton.addEventListener('click', resetAndShowSelection);
+            analysisBackButton.addEventListener('click', resetAndShowSelection);
+
+            // 초기화
+            renderSelectionScreen(); 
+            toggleInput(false, false); 
+
+        } catch (error) {
+            console.error("스크립트 실행 중 치명적인 오류 발생:", error);
+            document.body.innerHTML = `<div class="p-4 text-red-500">오류가 발생했습니다. 개발자 콘솔을 확인하세요. <br><br> ${error.stack}</div>`;
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- clone v5 into a new `job_simulation_v6.html`
- add analysis screen with radar chart
- call Gemini API with new analysis prompt
- show dynamic summary and trait descriptions
- allow returning to main menu from analysis screen

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_686be9a02d108323b1338bdba4f35c9e