### PR TITLE
Fix input placeholder and hint logic

### DIFF
--- a/job_simulation_v5.html
+++ b/job_simulation_v5.html
@@ -297,14 +297,18 @@
                 scrollToBottom();
             }
             
-            function toggleInput(mainInputEnabled, hintsAvailable) {
+            function toggleInput(mainInputEnabled, hintsAvailable, placeholder) {
                 messageInput.disabled = !mainInputEnabled;
                 submitButton.disabled = !mainInputEnabled;
                 showHintsButton.disabled = !hintsAvailable;
                 if (!mainInputEnabled || !hintsAvailable) {
                     hintButtonsContainer.innerHTML = '';
                 }
-                messageInput.placeholder = mainInputEnabled ? "어떻게 행동하시겠습니까?" : "게임이 종료되었습니다.";
+                if (placeholder !== undefined) {
+                    messageInput.placeholder = placeholder;
+                } else {
+                    messageInput.placeholder = mainInputEnabled ? "어떻게 행동하시겠습니까?" : "게임이 종료되었습니다.";
+                }
             }
 
             async function getLlmResponse() {
@@ -312,9 +316,8 @@
                     addMessage("오류: API 키가 설정되지 않았습니다. 스크립트 상단의 API_KEY 변수를 확인하세요."); 
                     return; 
                 }
-                toggleInput(false, false);
+                toggleInput(false, currentHints.length > 0, '답변 생성 중...');
                 toggleLoadingIndicator(true);
-                currentHints = [];
                 
                 try {
                     const response = await fetch(API_URL, { 
@@ -361,10 +364,11 @@
                         conversationHistory.push({ role: "model", parts: [{ text: storyText }] });
                     }
 
-                    let hintsAvailable = false;
+                    let hintsAvailable = currentHints.length > 0;
                     if (hintSplit.length > 1) {
-                        currentHints = hintSplit[1].trim().split(/\d\.\s*/).filter(Boolean).map(h => h.trim());
-                        if (currentHints.length > 0) {
+                        const newHints = hintSplit[1].trim().split(/\d\.\s*/).filter(Boolean).map(h => h.trim());
+                        if (newHints.length > 0) {
+                            currentHints = newHints;
                             hintsAvailable = true;
                         }
                     }

--- a/job_simulation_v6.html
+++ b/job_simulation_v6.html
@@ -366,14 +366,18 @@
                 scrollToBottom();
             }
             
-            function toggleInput(mainInputEnabled, hintsAvailable) {
+            function toggleInput(mainInputEnabled, hintsAvailable, placeholder) {
                 messageInput.disabled = !mainInputEnabled;
                 submitButton.disabled = !mainInputEnabled;
                 showHintsButton.disabled = !hintsAvailable;
                 if (!mainInputEnabled || !hintsAvailable) {
                     hintButtonsContainer.innerHTML = '';
                 }
-                messageInput.placeholder = mainInputEnabled ? "어떻게 행동하시겠습니까?" : "게임이 종료되었습니다.";
+                if (placeholder !== undefined) {
+                    messageInput.placeholder = placeholder;
+                } else {
+                    messageInput.placeholder = mainInputEnabled ? "어떻게 행동하시겠습니까?" : "게임이 종료되었습니다.";
+                }
             }
 
             async function getLlmResponse() {
@@ -381,9 +385,8 @@
                     addMessage("오류: API 키가 설정되지 않았습니다. 스크립트 상단의 API_KEY 변수를 확인하세요."); 
                     return; 
                 }
-                toggleInput(false, false);
+                toggleInput(false, currentHints.length > 0, '답변 생성 중...');
                 toggleLoadingIndicator(true);
-                currentHints = [];
                 
                 try {
                     const response = await fetch(API_URL, { 
@@ -430,10 +433,11 @@
                         conversationHistory.push({ role: "model", parts: [{ text: storyText }] });
                     }
 
-                    let hintsAvailable = false;
+                    let hintsAvailable = currentHints.length > 0;
                     if (hintSplit.length > 1) {
-                        currentHints = hintSplit[1].trim().split(/\d\.\s*/).filter(Boolean).map(h => h.trim());
-                        if (currentHints.length > 0) {
+                        const newHints = hintSplit[1].trim().split(/\d\.\s*/).filter(Boolean).map(h => h.trim());
+                        if (newHints.length > 0) {
+                            currentHints = newHints;
                             hintsAvailable = true;
                         }
                     }
@@ -453,11 +457,15 @@
             }
 
             function parseScoresText(text) {
-                const cleaned = text.trim()
-                    .replace(/^```(?:json)?\s*/i, '')
-                    .replace(/\s*```$/, '')
-                    .trim();
-                return JSON.parse(cleaned);
+                try {
+                    const cleaned = text.trim()
+                        .replace(/^```(?:json)?\s*/i, '')
+                        .replace(/\s*```$/, '')
+                        .trim();
+                    return JSON.parse(cleaned);
+                } catch (_) {
+                    return null;
+                }
             }
 
             async function startAnalysis() {
@@ -480,7 +488,11 @@
                     const data = await response.json();
                     const jsonText = data.candidates?.[0]?.content?.parts?.[0]?.text || '{}';
                     const scores = parseScoresText(jsonText);
-                    renderAnalysis(scores);
+                    if (scores) {
+                        renderAnalysis(scores);
+                    } else {
+                        analysisSummary.textContent = '성향 분석 결과를 가져오지 못했습니다.';
+                    }
                 } catch (e) {
                     analysisSummary.textContent = '분석 중 오류 발생: ' + e.message;
                 }


### PR DESCRIPTION
## Summary
- keep hint button enabled while loading replies
- preserve previous hints when no new ones are provided
- show loading placeholder instead of game over text
- guard against invalid JSON in trait analysis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c9e80d73c8323accc8576bd696f68